### PR TITLE
Add Stammtisch Stuttgart

### DIFF
--- a/stammtische/stuttgart/index.md
+++ b/stammtische/stuttgart/index.md
@@ -8,16 +8,16 @@ altfooter: true
 
 ## Willkommen beim OWASP-Stammtisch Stuttgart
 
-_Hinweis_: Der Stammtisch wird von uns (Johannes & Sven) aktuell wiederbelebt. Wir sind noch "neu im OWASP G'schäft". Daher ist die Seite hier noch nicht so ganz elaboriert 😬
+_Hinweis_: Der Stammtisch wird von uns (Johannes & Sven) aktuell wiederbelebt. Wir sind noch "neu im OWASP G'schäft", daher ist die Seite hier noch nicht so ganz elaboriert. 😬
 
-Der Stammtisch findet einmal im Quartal statt. Es gibt keinen festen Rhythms. Die Tage (Dienstag/Mittwoch/Donnerstag) durch, damit Leute mit Verpflichtung nan festen Tagen auch eine Chance haben zu kommen.
+Der Stammtisch findet einmal im Quartal statt. Es gibt keinen festen Rhythms. Die Tage (Dienstag/Mittwoch/Donnerstag) wechseln durch, damit Leute mit Verpflichtungen an festen Tagen auch eine Chance haben zu kommen.
 
 Die Termine werden via Meetup und Mailingliste ([germany-chapter@owasp.org](mailto:germany-chapter@owasp.org), [Mailarchiv](https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter)) bekannt gegeben.
 
 ### Anstehende Termine
 
-* 6.6.24: TBD
-* 17.9.24: TBD
-* 10.12.24: TBD
+* 06.06.2024: TBD
+* 17.09.2024: TBD
+* 10.12.2024: TBD
 
 ### Vergangene Termine

--- a/stammtische/stuttgart/index.md
+++ b/stammtische/stuttgart/index.md
@@ -6,13 +6,18 @@ altfooter: true
 
 ---
 
-## OWASP Stammtisch Stuttgart
+## Willkommen beim OWASP-Stammtisch Stuttgart
 
-🔧 TODO
+_Hinweis_: Der Stammtisch wird von uns (Johannes & Sven) aktuell wiederbelebt. Wir sind noch "neu im OWASP G'schäft". Daher ist die Seite hier noch nicht so ganz elaboriert 😬
 
-### **T E R M I N E:**
+Der Stammtisch findet einmal im Quartal statt. Es gibt keinen festen Rhythms. Die Tage (Dienstag/Mittwoch/Donnerstag) durch, damit Leute mit Verpflichtung nan festen Tagen auch eine Chance haben zu kommen.
 
-<span style="font-size:130%;">Termine werden über die Mailing-Liste von OWASP Germany angekündigt
-([germany-chapter@owasp.org](mailto:germany-chapter@owasp.org)),
-[Mailarchiv](https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter)</span>
+Die Termine werden via Meetup und Mailingliste ([germany-chapter@owasp.org](mailto:germany-chapter@owasp.org), [Mailarchiv](https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter)) bekannt gegeben.
 
+### Anstehende Termine
+
+* 6.6.24: TBD
+* 17.9.24: TBD
+* 10.12.24: TBD
+
+### Vergangene Termine

--- a/stammtische/stuttgart/index.md
+++ b/stammtische/stuttgart/index.md
@@ -6,18 +6,6 @@ altfooter: true
 
 ---
 
-## Willkommen beim OWASP-Stammtisch Stuttgart
+## Welcome to OWASP Stammtisch Stuttgart
 
-_Hinweis_: Der Stammtisch wird von uns (Johannes & Sven) aktuell wiederbelebt. Wir sind noch "neu im OWASP G'schäft", daher ist die Seite hier noch nicht so ganz elaboriert. 😬
-
-Der Stammtisch findet einmal im Quartal statt. Es gibt keinen festen Rhythms. Die Tage (Dienstag/Mittwoch/Donnerstag) wechseln durch, damit Leute mit Verpflichtungen an festen Tagen auch eine Chance haben zu kommen.
-
-Die Termine werden via Meetup und Mailingliste ([germany-chapter@owasp.org](mailto:germany-chapter@owasp.org), [Mailarchiv](https://groups.google.com/a/owasp.org/forum/#!forum/germany-chapter)) bekannt gegeben.
-
-### Anstehende Termine
-
-* 06.06.2024: TBD
-* 17.09.2024: TBD
-* 10.12.2024: TBD
-
-### Vergangene Termine
+_Stammtisch_ is a special thing in Germany and does not really fit into the organizational structure of OWASP. Thus, new _Stammtische_ need to be a chapter. So, all further information can be found at the [OWASP Chapter Stuttgart](https://owasp.org/www-chapter-stuttgart/) site.  

--- a/stammtische/stuttgart/info.md
+++ b/stammtische/stuttgart/info.md
@@ -1,14 +1,14 @@
 ### Navigation ([🔙](/www-chapter-germany/stammtische/#lokale-stammtische))
 
-* zurück zu [OWASP Germany](/www-chapter-germany/)
-* zurück zu [Lokale Stammtische](/www-chapter-germany/stammtische/#lokale-stammtische)
+* back to [OWASP Germany](/www-chapter-germany/)
+* back to [Lokale Stammtische](/www-chapter-germany/stammtische/#lokale-stammtische)
 * [Stammtisch FAQ](/www-chapter-germany/stammtische/#stammtisch-faq)
 
-### Kontakt
+### Social Links
 
-* TODO
+* [Meetup.com](https://www.meetup.com/OWASP-Stuttgart/)
 
-### Weitere Stammtisch Informationen
+### Further Stuttgart Stammtisch Information
 
 * [Speaker Agreement](https://www.owasp.org/index.php/Speaker_Agreement)
 * [Code of Conduct](https://www.owasp.org/index.php/Governance/Conference_Policies)

--- a/stammtische/stuttgart/info.md
+++ b/stammtische/stuttgart/info.md
@@ -1,9 +1,15 @@
 ### Navigation ([🔙](/www-chapter-germany/stammtische/#lokale-stammtische))
 
+* zurück zu [OWASP Germany](/www-chapter-germany/)
 * zurück zu [Lokale Stammtische](/www-chapter-germany/stammtische/#lokale-stammtische)
 * [Stammtisch FAQ](/www-chapter-germany/stammtische/#stammtisch-faq)
 
-
 ### Kontakt
 
-* [Meetup](ihttps://www.meetup.com/OWASP-Stuttgart-Stammtisch/)
+* TODO
+
+### Weitere Stammtisch Informationen
+
+* [Speaker Agreement](https://www.owasp.org/index.php/Speaker_Agreement)
+* [Code of Conduct](https://www.owasp.org/index.php/Governance/Conference_Policies)
+* [Welcome to OWASP](https://docs.google.com/presentation/d/1RmffoNABrybyZ1euCKPyqqqGy09pil4aMhqLuU3sQgc/edit#slide=id.g7ee8866183_0_181)

--- a/stammtische/stuttgart/leaders.md
+++ b/stammtische/stuttgart/leaders.md
@@ -1,4 +1,4 @@
 ### Organisatoren
 
 * [Johannes Merkert](mailto:johannes.merkert@owasp.org)
-* [Sven Strittmatter](mailto:sven.strittmatter@owasp.org)
+* [Sven Strittmatter (aka. Weltraumschaf)](mailto:sven.strittmatter@owasp.org)

--- a/stammtische/stuttgart/leaders.md
+++ b/stammtische/stuttgart/leaders.md
@@ -1,4 +1,4 @@
 ### Organisatoren
 
-* `<Organisator 1>`
-* `<Organisator 2>`
+* [Johannes Merkert](mailto:johannes.merkert@owasp.org)
+* [Sven Strittmatter](mailto:sven.strittmatter@owasp.org)


### PR DESCRIPTION
Since new Stammtische are forced to found a chapter, we link to the new Stuttgart chapter site (WIP) to reduce duplicate content to maintain.